### PR TITLE
feat(tabbar): add badge support on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+* Adds tab bar badges on iOS (`badge`).
+
 ## 0.1.1
 
 * Adds link to blog post in readme.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,11 @@ int _tabIndex = 0;
 // Overlay this at the bottom of your page
 CNTabBar(
   items: const [
-    CNTabBarItem(label: 'Home', icon: CNSymbol('house.fill')),
+    CNTabBarItem(
+      label: 'Home',
+      icon: CNSymbol('house.fill'),
+      badge: '3', // iOS only; set empty string to hide
+    ),
     CNTabBarItem(label: 'Profile', icon: CNSymbol('person.crop.circle')),
     CNTabBarItem(label: 'Settings', icon: CNSymbol('gearshape.fill')),
   ],

--- a/ios/Classes/Views/CupertinoTabBarPlatformView.swift
+++ b/ios/Classes/Views/CupertinoTabBarPlatformView.swift
@@ -31,6 +31,7 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
     var rightCount: Int = 1
     var leftInset: CGFloat = 0
     var rightInset: CGFloat = 0
+    var badges: [String] = []
 
     if let dict = args as? [String: Any] {
       labels = (dict["labels"] as? [String]) ?? []
@@ -46,6 +47,7 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
       if let s = dict["split"] as? NSNumber { split = s.boolValue }
       if let rc = dict["rightCount"] as? NSNumber { rightCount = rc.intValue }
       if let sp = dict["splitSpacing"] as? NSNumber { splitSpacingVal = CGFloat(truncating: sp) }
+      if let b = dict["badges"] as? [String] { badges = b }
       // content insets controlled by Flutter padding; keep zero here
     }
 
@@ -64,7 +66,13 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
         var image: UIImage? = nil
         if i < symbols.count { image = UIImage(systemName: symbols[i]) }
         let title = (i < labels.count) ? labels[i] : nil
-        items.append(UITabBarItem(title: title, image: image, selectedImage: image))
+        let item = UITabBarItem(title: title, image: image, selectedImage: image)
+        if i < badges.count {
+          let val = badges[i]
+          item.badgeValue = val.isEmpty ? nil : val
+        }
+        
+        items.append(item)
       }
       return items
     }
@@ -164,6 +172,7 @@ channel.setMethodCallHandler { [weak self] call, result in
         if let args = call.arguments as? [String: Any] {
           let labels = (args["labels"] as? [String]) ?? []
           let symbols = (args["sfSymbols"] as? [String]) ?? []
+          let badges = (args["badges"] as? [String]) ?? []
           let selectedIndex = (args["selectedIndex"] as? NSNumber)?.intValue ?? 0
           self.currentLabels = labels
           self.currentSymbols = symbols
@@ -173,7 +182,13 @@ channel.setMethodCallHandler { [weak self] call, result in
               var image: UIImage? = nil
               if i < symbols.count { image = UIImage(systemName: symbols[i]) }
               let title = (i < labels.count) ? labels[i] : nil
-              items.append(UITabBarItem(title: title, image: image, selectedImage: image))
+              let item = UITabBarItem(title: title, image: image, selectedImage: image)
+              if i < badges.count {
+                let val = badges[i]
+                item.badgeValue = val.isEmpty ? nil : val
+              }
+              
+              items.append(item)
             }
             return items
           }
@@ -211,6 +226,7 @@ channel.setMethodCallHandler { [weak self] call, result in
           self.tabBarRight?.removeFromSuperview(); self.tabBarRight = nil
           let labels = self.currentLabels
           let symbols = self.currentSymbols
+          let badges: [String] = []
           let appearance: UITabBarAppearance? = {
             if #available(iOS 13.0, *) { let ap = UITabBarAppearance(); ap.configureWithDefaultBackground(); return ap }
             return nil
@@ -221,7 +237,13 @@ channel.setMethodCallHandler { [weak self] call, result in
               var image: UIImage? = nil
               if i < symbols.count { image = UIImage(systemName: symbols[i]) }
               let title = (i < labels.count) ? labels[i] : nil
-              items.append(UITabBarItem(title: title, image: image, selectedImage: image))
+              let item = UITabBarItem(title: title, image: image, selectedImage: image)
+              if i < badges.count {
+                let val = badges[i]
+                item.badgeValue = val.isEmpty ? nil : val
+              }
+              
+              items.append(item)
             }
             return items
           }

--- a/lib/components/tab_bar.dart
+++ b/lib/components/tab_bar.dart
@@ -8,13 +8,16 @@ import '../style/sf_symbol.dart';
 /// Immutable data describing a single tab bar item.
 class CNTabBarItem {
   /// Creates a tab bar item description.
-  const CNTabBarItem({this.label, this.icon});
+  const CNTabBarItem({this.label, this.icon, this.badge});
 
   /// Optional tab item label.
   final String? label;
 
   /// Optional SF Symbol for the item.
   final CNSymbol? icon;
+
+  /// Optional badge value to display on the item (iOS only).
+  final String? badge;
 }
 
 /// A Cupertino-native tab bar. Uses native UITabBar/NSTabView style visuals.
@@ -133,12 +136,14 @@ class _CNTabBarState extends State<CNTabBar> {
     final colors = widget.items
         .map((e) => resolveColorToArgb(e.icon?.color, context))
         .toList();
+    final badges = widget.items.map((e) => e.badge ?? '').toList();
 
     final creationParams = <String, dynamic>{
       'labels': labels,
       'sfSymbols': symbols,
       'sfSymbolSizes': sizes,
       'sfSymbolColors': colors,
+      'badges': badges,
       'selectedIndex': widget.currentIndex,
       'isDark': _isDark,
       'split': widget.split,
@@ -232,11 +237,13 @@ class _CNTabBarState extends State<CNTabBar> {
     // Items update (for hot reload or dynamic changes)
     final labels = widget.items.map((e) => e.label ?? '').toList();
     final symbols = widget.items.map((e) => e.icon?.name ?? '').toList();
+    final badges = widget.items.map((e) => e.badge ?? '').toList();
     if (_lastLabels?.join('|') != labels.join('|') ||
         _lastSymbols?.join('|') != symbols.join('|')) {
       await ch.invokeMethod('setItems', {
         'labels': labels,
         'sfSymbols': symbols,
+        'badges': badges,
         'selectedIndex': widget.currentIndex,
       });
       _lastLabels = labels;


### PR DESCRIPTION
### Summary
Adds native badge support to `CNTabBar` on iOS using `UITabBarItem.badgeValue`

### Changes
- Added `badge` field to `CNTabBarItem`
- Propagated badge data through platform channel to native iOS implementation
- Updated example app to demonstrate badge usage

### Behavior
- ✅ iOS: Native badge rendering
- 🧪 Tested on: iPhone (iOS 17.x) — badges appear and update correctly
<img width="375" height="667" alt="Ekran Resmi 2025-10-09 - 13 16 47" src="https://github.com/user-attachments/assets/6a4c2fa1-89a0-4fc7-90ab-3c4b8dc127d7" />